### PR TITLE
added a default constructor

### DIFF
--- a/include/lambda_lanczos/lambda_lanczos.hpp
+++ b/include/lambda_lanczos/lambda_lanczos.hpp
@@ -52,10 +52,10 @@ public:
 template <typename T>
 class LambdaLanczos {
 public:
-  LambdaLanczos() {}
+  LambdaLanczos();
   LambdaLanczos(std::function<void(const vector<T>&, vector<T>&)> mv_mul, int matrix_size, bool find_maximum);
   LambdaLanczos(std::function<void(const vector<T>&, vector<T>&)> mv_mul, int matrix_size) : LambdaLanczos(mv_mul, matrix_size, false) {}
-  
+
   int matrix_size;
   int max_iteration;
   real_t<T> eps = minimum_effective_decimal<real_t<T>>() * 1e3;
@@ -66,8 +66,15 @@ public:
 
   std::function<void(const vector<T>&, vector<T>&)> mv_mul;
   std::function<void(vector<T>&)> init_vector = VectorRandomInitializer<T>::init;
-
   int run(real_t<T>&, vector<T>&) const;
+
+  int  SetSize(int matrix_size);
+  void SetInitVec(std::function<void(vector<T>&)> init_vector);
+  void SetMul(std::function<void(const vector<T>&, vector<T>&)> mv_mul);
+  void SetFindMax(bool find_maximum);
+  void SetEvalOffset(T offset);
+  void SetEpsilon(T epsilon);
+  void SetTriEpsRatio(T tri_eps_ratio);
 
 private:
   static void schmidt_orth(vector<T>&, const vector<vector<T>>&);
@@ -88,6 +95,14 @@ private:
 /* Implementation */
 
 template <typename T>
+inline LambdaLanczos<T>::LambdaLanczos() {
+  this->matrix_size = 0;
+  this->max_iteration = 0;
+  this->find_maximum = 0;
+}
+
+
+template <typename T>
 inline LambdaLanczos<T>::LambdaLanczos(std::function<void(const vector<T>&, vector<T>&)> mv_mul,
 				int matrix_size, bool find_maximum) {
   this->mv_mul = mv_mul;
@@ -99,6 +114,7 @@ inline LambdaLanczos<T>::LambdaLanczos(std::function<void(const vector<T>&, vect
 
 template <typename T>
 inline int LambdaLanczos<T>::run(real_t<T>& eigvalue, vector<T>& eigvec) const {
+  assert(matrix_size > 0);
   assert(0 < this->tridiag_eps_ratio && this->tridiag_eps_ratio < 1);
   
   vector<vector<T>> u;     // Lanczos vectors
@@ -344,6 +360,53 @@ inline int LambdaLanczos<T>::num_of_eigs_smaller_than(real_t<T> c,
 
   return count;
 }
+
+
+template <typename T>
+inline int LambdaLanczos<T>::SetSize(int matrix_size)
+{
+  this->matrix_size = matrix_size;
+  this->max_iteration = matrix_size;
+  return matrix_size;
+}
+
+template <typename T>
+inline void LambdaLanczos<T>::SetMul(std::function<void(const vector<T>&, vector<T>&)> mv_mul)
+{
+  this->mv_mul = mv_mul;
+}
+
+template <typename T>
+inline void LambdaLanczos<T>::SetInitVec(std::function<void(vector<T>&)> init_vector)
+{
+  this->init_vector = init_vector;
+}
+
+template <typename T>
+inline void LambdaLanczos<T>::SetFindMax(bool find_maximum) {
+  this->find_maximum = find_maximum;
+}
+
+template <typename T>
+inline void LambdaLanczos<T>::SetEvalOffset(T offset)
+{ 
+  this->eigenvalue_offset = offset;
+}
+
+template <typename T>
+inline void LambdaLanczos<T>::SetEpsilon(T epsilon)
+{ 
+  this->eps = epsilon;
+}
+
+template <typename T>
+inline void LambdaLanczos<T>::SetTriEpsRatio(T tri_eps_ratio)
+{ 
+  this->tridiag_eps_ratio = tri_eps_ratio;
+}
+
+
+
 
 
 template <typename T>

--- a/include/lambda_lanczos/lambda_lanczos.hpp
+++ b/include/lambda_lanczos/lambda_lanczos.hpp
@@ -52,6 +52,7 @@ public:
 template <typename T>
 class LambdaLanczos {
 public:
+  LambdaLanczos() {}
   LambdaLanczos(std::function<void(const vector<T>&, vector<T>&)> mv_mul, int matrix_size, bool find_maximum);
   LambdaLanczos(std::function<void(const vector<T>&, vector<T>&)> mv_mul, int matrix_size) : LambdaLanczos(mv_mul, matrix_size, false) {}
   


### PR DESCRIPTION
## Changes

In the current version, the user must pass lambda expression to the *mv_mul* argument of the constructor.  Is this necessary?  Is it okay if I add a default constructor?   This pull request includes a constructor that requires no arguments (*LambdaLanczos::LambdaLanczos()*).

I also added some "Set()" functions (but these are not important to me).

## Summary

I added this because am trying to define a new class (eg *PEigenCalculator*) which contains a LambdaLanczos as a data member (*ll_engine*).  I created this wrapper so that people who don't like lamda-expressions can use "PEigenCalculator" instead of *LambdaLanczos*.  Unfortunately, I could not figure out how to write the constructor for *PEigenCalculator*.  I added a default constructor (*LambdaLanczos::LambdaLanczos()*) to make it easier to write *PEigenCalculator::PEigenCalculator()*.

### Details (feel free to skip)

When initializing the "ll_engine" member, I could not figure out how to supply the lambda expression that *LambdaLanczos()* contructor needs as an argument.  So I created a constructor for *LambdaLanczor* that requires no arguments.

Is this a bad idea?  Is there another way?
(I admit I am not very familiar with lambda expressions in C++11.)

### More Details:

   The user must eventually specify the size of the matrix, and the matrix before invoking *run()*.  I added an *assert(matrix_size > 0);* statement at the beginning of *LambdaLanczos::run()* to guarantee this.

### Example code:

```
template<typename Scalar>
class PEigenCalculator {
  size_t n;                  // the size of the matrix
  vector<vector<Scalar> > M; // the matrix
  vector<Scalar> evec;       // preallocated vector (needed by lambda_lanzcos)
  LambdaLanczos<Scalar> ll_engine;  // this is the object that does the work
  void Init();
public:
  /// constructor
  PEigenCalculator(int n=0, bool findmax = false):ll_engine() {
    Init(n, findmax);
  }

  /// @brief  Calculate the principal eigenvalue and eigenvector of a matrix.
  /// @return Return the principal eigenvalue of the matrix.
  ///         If you want the eigenvector, pass a non-null "evec" argument.
  Scalar
  PrincipalEigen(Scalar const* const *matrix,  //!< the input patrix
                 Scalar *eigenvector=nullptr);   //!< optional: store eigenvector
}; // class PEigenCalculator
```

*(For completeness, I will attach the "peigencalc.hpp" file which defines "PEigenCalculator".  Feel free to ignore this file.)*

### Get() and Set() commands?

Do you think it is a good idea to make the data members private?
```
template <typename T>
class LambdaLanczos {
public:
  // ...
  int matrix_size;
  int max_iteration;
  real_t<T> eps = minimum_effective_decimal<real_t<T>>() * 1e3;
  real_t<T> tridiag_eps_ratio = 1e-1;
  int initial_vector_size = 200;
  bool find_maximum = false;
  real_t<T> eigenvalue_offset = 0.0;
  //...
}
```

 I also added some "Set()" commands to allow users to modify the data members of LambdaLanczos.  (Perhaps these are not necessary.)  I did not add "Get()" functions yet.

Thanks again for creating lambda-lanczos

-Andrew
