### PR TITLE
added .travis.yml, codecov.yml, and badges to README.md file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,47 @@
+# helpful link:
+#https://stackoverflow.com/questions/27644586/how-to-set-up-travis-ci-with-multiple-languages
+
+
+matrix:
+  include:
+
+    - language: cpp
+      compiler: gcc
+      # "dist" specifies the operating system ("bionic"=ubuntu18.04)
+      dist: bionic
+      #install:
+      #  Optional: To test the output of your program after running, you can use
+      #  - git clone https://github.com/kward/shunit2 shunit2
+      script:
+        - g++ -std=c++14 -I./include ./src/lambda_lanczos_test/lambda_lanczos_test.cpp -o lambda_lanczos_test
+        - ./lambda_lanczos_test
+        # ---- Optional: Code-coverage tests: ----
+        #- g++ -g -O0 -coverage -fno-inline -std=c++14 -I./include ./src/lambda_lanczos_test/lambda_lanczos_test.cpp -o lambda_lanczos_test
+        #- ./lambda_lanczos_test
+        # ---- Optional: check for memory errors (probably not needed) ----
+        #- g++ -g -O0  -std=c++14 -I./include ./src/lambda_lanczos_test/lambda_lanczos_test.cpp -o lambda_lanczos_test
+        #- valgrind --leak-check=yes --error-exitcode=1 ./lambda_lanczos_test
+      #after_success:
+      # ---- Optional: Report code-coverage test results to codecov.io ----
+      #  - bash <(curl -s https://codecov.io/bash)
+
+
+    - language: cpp
+      compiler: clang
+      # "dist" specifies the operating system ("bionic"=ubuntu18.04)
+      dist: bionic
+      #install:
+      #  Optional: To test the output of your program after running, you can use
+      #  - git clone https://github.com/kward/shunit2 shunit2
+      script:
+        - clang++ -std=c++14 -I./include ./src/lambda_lanczos_test/lambda_lanczos_test.cpp -o lambda_lanczos_test
+        - ./lambda_lanczos_test
+        # ---- Optional: Code-coverage tests: ----
+        #- clang++ -g -O0 -coverage -fno-inline -std=c++14 -I./include ./src/lambda_lanczos_test/lambda_lanczos_test.cpp -o lambda_lanczos_test
+        #- ./lambda_lanczos_test
+        # ---- Optional: check for memory errors (probably not needed) ----
+        #- clang++ -g -O0  -std=c++14 -I./include ./src/lambda_lanczos_test/lambda_lanczos_test.cpp -o lambda_lanczos_test
+        #- valgrind --leak-check=yes --error-exitcode=1 ./lambda_lanczos_test
+      #after_success:
+      # ---- Optional: Report code-coverage test results to codecov.io ----
+      #  - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
       # "dist" specifies the operating system ("bionic"=ubuntu18.04)
       dist: bionic
       #install:
+      #  - sudo apt-get install valgrind
       #  Optional: To test the output of your program after running, you can use
       #  - git clone https://github.com/kward/shunit2 shunit2
       script:
@@ -31,6 +32,7 @@ matrix:
       # "dist" specifies the operating system ("bionic"=ubuntu18.04)
       dist: bionic
       #install:
+      #  - sudo apt-get install valgrind
       #  Optional: To test the output of your program after running, you can use
       #  - git clone https://github.com/kward/shunit2 shunit2
       script:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# Lambda Lanczos
+[![Build Status](https://travis-ci.org/mrcdr/lambda-lanczos.svg?branch=master)](https://travis-ci.org/mrcdr/lambda-lanczos.svg?branch=master)
+[![codecov](https://codecov.io/gh/mrcdr/lambda-lanczos/branch/master/graph/badge.svg)](https://codecov.io/gh/mrcdr/lambda-lanczos)
+[![License](https://img.shields.io/badge/License-MIT-green.svg)]()
+[![GitHub code size in bytes](https://img.shields.io/github/languages/code-size/mrcdr/lambda-lanczos)]()
+
+Lambda Lanczos
+===========
 
 C++ adaptive and header-only Lanczos algorithm library
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "src"    # Ignore the "src" directory. (Only measure coverage in "include")


### PR DESCRIPTION
I added a (somewhat complicated) example of a .travis.yml file which compiles and runs your test program using both g++ and clang++.  You will have to go to https://travis-ci.org, log in using your git password, and click on the lambda-lanczos repository (from your list of repositories) to enable automatic testing before this will work.  This was working with an earlier version of your test file (when using assert() statements, not gtest).  However it is not yet working with your current version of *lambda_lanczos_test.cpp* (in the *develop* branch).  I am not familiar enough with gtest to offer any advice.

I also added several optional testing features to your .travis.yml file.  I commented all of them out.  Feel free to uncomment the features you want:

1) I added code-coverage to your tests.  This will verify that all of the code in the "include" directory was tested by the program(s) in your .travis.yml file.  If it works, you should see a badge that resembles this at the top of your readme file:

![codecov_badge](https://codecov.io/gh/jewettaij/jacobi_pd/branch/master/graph/badge.svg)

For this to work, you will have to uncomment the lines in the .travis.yml file which add the "-coverage" argument to the compiler.  Then visit https://codecov.io, log in with your github credentials, and click on your repository to enable coverage.

If you don't want this, edit your README.md, and remove the line at the top containing https://codecov.io, so that the badge does not appear.

2) I added a memory checker (valgrind).  You might not need this.  Valgrind is very useful for my work because I often use "new" and "delete" to allocate memory.  (It seems like you don't do this.)  However valgrind is still useful to report errors if you accidentally read (or write) past the end of an array.  Currently, the valgrind memory checking code is commented out, but it's easy to enable it.

3) Additional testing with "shunit2".  (You probably don't need this.)
Some of my testing programs will create a file after they are finished.  For these programs, I need to read the contents of this file to see if my program behaved correctly.  That's what "shunit2" is useful for.   Here is an example of its use:

https://github.com/jewettaij/visfd/blob/master/.travis.yml
It invokes these files:
https://github.com/jewettaij/visfd/blob/master/tests/test_fluctuation_filter.sh
https://github.com/jewettaij/visfd/blob/master/tests/test_membrane_detection.sh
...

*(Note: Some people prefer to use "bats" instead of "shunit2".)*

Again, you probably don't need this for this repository.
This is currently commented out.

Hope this is useful!

Andrew